### PR TITLE
Added hint for http://caniuse.com/#search=canvas in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the [example](//consbio.github.io/Leaflet.UTFGrid).
 *Only supports Leaflet 1.0*  
 (tested on Leaflet 1.0 beta 1). 
 
-Note: only supports browsers that provide ```<canvas>```. 
+Note: only supports browsers that provide [canvas](http://caniuse.com/#search=canvas). 
 
 
 


### PR DESCRIPTION
May it's helpful to provide a link for a quick overview which browsers support the canvas element.
